### PR TITLE
Support for multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ zgenom load empresslabs/gitprofiles.plugin.zsh
 zplug empresslabs/gitprofiles.plugin.zsh
 ```
 
-#### [antibody](https://github.com/getantibody/antibody)
+#### [antidote](https://github.com/mattmc3/antidote.git)
 
-Add the following to your .zsh_plugins.txt file for antibody:
+Add the following to your .zsh_plugins.txt file for antidote:
 
 ```shell
 empresslabs/gitprofiles.plugin.zsh

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ zgenom load empresslabs/gitprofiles.plugin.zsh
 zplug empresslabs/gitprofiles.plugin.zsh
 ```
 
+#### [antibody](https://github.com/getantibody/antibody)
+
+Add the following to your .zsh_plugins.txt file for antibody:
+
+```shell
+empresslabs/gitprofiles.plugin.zsh
+```
+
 ## Usage
 
 #### Define where your profiles are stored
@@ -73,5 +81,17 @@ zstyle ":empresslabs:git:profile" path "$HOME/.config/git/profiles"
   name = Bruno Sales
   email = work@baliestri.dev
   # signingkey = 1234567890
-  path = "/home/baliestri/work"
+  paths = "/home/baliestri/work"
+
+[profile "personal"]
+  name = Bruno Sales
+  email = personal@baliestri.dev
+  # signingkey = 1234567890
+  paths = "~/personal",
+    "~/src/personal/*",
+    "~/src/mytopsecretproject"
 ```
+
+Multiple paths can be defined for a profile, separated by either newline or commas. The paths are processed in the order they are defined, with exact matches taking precedence over wild card matches. Tildes are expanded to ${HOME}.
+
+It is possible to get debug information by setting the `GP_DEBUG` environment variable to any value within your current session.

--- a/gitprofiles.plugin.zsh
+++ b/gitprofiles.plugin.zsh
@@ -1,6 +1,7 @@
 # Copyright (c) Bruno Sales <me@baliestri.dev>. Licensed under the MIT License.
 # See the LICENSE file in the project root for full license information.
 
+# vim: set ts=4 sw=4 tw=0 et :
 #!/usr/bin/env zsh
 
 function __gitprofiles_hook() {
@@ -9,8 +10,8 @@ function __gitprofiles_hook() {
     return 1
   fi
 
-  local -A profile_path_map=()
-  local -A profile_cfg_map=()
+  typeset -A profile_paths_map
+  typeset -A profile_cfg_map
 
   ## Get the path to the profile file
   zstyle -s ":empresslabs:git:profile" path profile_filepath
@@ -29,28 +30,31 @@ function __gitprofiles_hook() {
     return 1
   fi
 
+  # Function to parse paths into an array
+  function __parse_paths() {
+    local raw_paths="$1"
+    echo ${(s:,:)raw_paths}  # Split by comma
+  }
+
   ## Iterate over all profiles to get the name, email, signingkey and path
   for profile in ${profiles}; do
-    local -A profile_value_map=()
+    typeset -A profile_value_map
 
     while read -r key value; do
       case "${key}" in
-        name)
-          profile_value_map[name]="${value}"
+        name|email|signingkey)
+          profile_value_map[${key}]="${value}"
           ;;
-        email)
-          profile_value_map[email]="${value}"
-          ;;
-        signingkey)
-          profile_value_map[signingkey]="${value}"
-          ;;
-        path)
-          profile_value_map[path]="${value}"
+        path|paths)
+          profile_value_map[paths]="${value}"
           ;;
       esac
     done < <(awk -F ' = ' '/^\[profile/{p=0} /^\[profile "[^"]*'"${profile}"'"/{p=1} p {gsub(/"/, "", $2); print $1,$2}' ${profile_filepath})
 
-    profile_path_map[${profile}]="${profile_value_map[path]}"
+    # Parse paths
+    if [[ -n "${profile_value_map[paths]}" ]]; then
+      profile_paths_map[${profile}]="$(__parse_paths "${profile_value_map[paths]}")"
+    fi
 
     profile_cfg_map[${profile}.name]="${profile_value_map[name]}"
     profile_cfg_map[${profile}.email]="${profile_value_map[email]}"
@@ -60,31 +64,47 @@ function __gitprofiles_hook() {
     fi
   done
 
-  ## Get the current directory
-  local -A current=()
-  current[dir]=$(pwd)
+  # Get current directory
+  local current_dir=$(pwd)
+  local matched_profile="default"
 
-  ## Check if the current directory is in one of the profiles paths
-  for profile in ${(k)profile_path_map}; do
-    if [[ "${current[dir]}" =~ "${profile_path_map[${profile}]}" ]]; then
-      local current[profile]="${profile}"
-      break
-    fi
+  # Check if current directory matches any profile paths
+  for profile in ${(k)profile_paths_map}; do
+    local paths=(${=profile_paths_map[${profile}]})  # Convert to array
+
+    for path_pattern in $paths; do
+      # Remove leading/trailing whitespace
+      path_pattern="${path_pattern## }"
+      path_pattern="${path_pattern%% }"
+
+      if [[ "${current_dir}" =~ "${path_pattern}" ]]; then
+        matched_profile="${profile}"
+        break 2
+      fi
+    done
   done
 
-  ## If the current directory is not in any profile path, use the default profile
-  if [[ -z "${current[profile]}" ]]; then
-    local current[profile]="default"
-  fi
-
   ## Set the current profile name and email
-  git config --global user.name "${profile_cfg_map[${current[profile]}.name]}"
-  git config --global user.email "${profile_cfg_map[${current[profile]}.email]}"
+  git config --global user.name "${profile_cfg_map[${matched_profile}.name]}"
+  git config --global user.email "${profile_cfg_map[${matched_profile}.email]}"
 
   ## Set the current profile signingkey if it exists
-  if [[ -n "${profile_cfg_map[${current[profile]}.signingkey]}" ]]; then
-    git config --global user.signingkey "${profile_cfg_map[${current[profile]}.signingkey]}"
+  if [[ -n "${profile_cfg_map[${matched_profile}.signingkey]}" ]]; then
+    git config --global user.signingkey "${profile_cfg_map[${matched_profile}.signingkey]}"
+  fi
+
+  # Print debug information if DEBUG is set
+  if [[ -n "${DEBUG}" ]]; then
+    echo "Current directory: ${current_dir}"
+    echo "Matched profile: ${matched_profile}"
+    echo "Using configuration:"
+    echo "  name: ${profile_cfg_map[${matched_profile}.name]}"
+    echo "  email: ${profile_cfg_map[${matched_profile}.email]}"
+    if [[ -n "${profile_cfg_map[${matched_profile}.signingkey]}" ]]; then
+      echo "  signingkey: ${profile_cfg_map[${matched_profile}.signingkey]}"
+    fi
   fi
 }
+
 
 add-zsh-hook chpwd __gitprofiles_hook

--- a/gitprofiles.plugin.zsh
+++ b/gitprofiles.plugin.zsh
@@ -46,7 +46,7 @@ function __gitprofiles_hook() {
       expanded_paths+=($path)
     done
 
-    echo $(expanded_paths}
+    echo ${expanded_paths}
   }
 
   ## Iterate over all profiles to get the name, email, signingkey and path

--- a/gitprofiles.plugin.zsh
+++ b/gitprofiles.plugin.zsh
@@ -35,15 +35,22 @@ function __gitprofiles_hook() {
 
   # Function to parse paths into an array and support tidle expansion
   function __parse_paths() {
-    local raw_paths="${(j:\n:)@}" # join on newlines
-    local paths=(${(f)${(s:,:)raw_paths}}) # split on commas & newlines
+    local raw_paths="${(j:\n:)@}"              # join args with newlines
+    local temp=(${(s:,:)raw_paths})           # split on commas first
+    # Now split each part by newlines
+    local paths=()
+    for part in $temp; do
+      paths+=(${(f)part})                     # split on newlines
+    done
 
-    paths=(${paths##[[:space:]]})   # Trim leading spaces
-    paths=(${paths%%[[:space:]]})   # Trim trailing spaces
-    paths=(${~paths})               # Expand tilde
-     paths=(${paths:#})             # Remove empty elements
+    # Process each path
+    paths=(${paths##[[:space:]]})             # Trim leading spaces
+    paths=(${paths%%[[:space:]]})             # Trim trailing spaces
+    paths=(${~paths})                         # Expand tilde
+    paths=(${paths:#})                        # Remove empty elements
+
     echo ${paths}
-  }
+}
 
   ## Iterate over all profiles to get the name, email, signingkey and path
   for profile in ${profiles}; do

--- a/gitprofiles.plugin.zsh
+++ b/gitprofiles.plugin.zsh
@@ -30,10 +30,23 @@ function __gitprofiles_hook() {
     return 1
   fi
 
-  # Function to parse paths into an array
+  # Function to parse paths into an array and support tidle expansion
   function __parse_paths() {
     local raw_paths="$1"
-    echo ${(s:,:)raw_paths}  # Split by comma
+    # First split by comma
+    local paths=(${(s:,:)raw_paths})
+
+    # Then expand each path
+    local expanded_paths=()
+    for path in $paths; do
+      # Trim whitespace and expand tilde
+      path="${path## }"
+      path="${path%% }"
+      path="${path:gs/~/$HOME}"
+      expanded_paths+=($path)
+    done
+
+    echo $(expanded_paths}
   }
 
   ## Iterate over all profiles to get the name, email, signingkey and path

--- a/gitprofiles.plugin.zsh
+++ b/gitprofiles.plugin.zsh
@@ -90,6 +90,11 @@ function __gitprofiles_hook() {
       path_pattern="${path_pattern## }"
       path_pattern="${path_pattern%% }"
 
+      if [[ -n "${DEBUG}"]]; then
+        echo "Checking path pattern: ${path_pattern}"
+        echo "Current directory: ${current_dir}"
+      fi
+
       if [[ "${current_dir}" =~ "${path_pattern}" ]]; then
         matched_profile="${profile}"
         break 2


### PR DESCRIPTION
I extended your excellent gitprofiles zsh plugin to support a few extras for my own purposes:

* allow specifying multiple paths
* select exact path matches over wildcards, meaning nested git repositories can be in different profiles
* exit early if we're not in a git repository
* support tilde definitions in paths and expand them during parsing

Please feel free to review as you see fit :)